### PR TITLE
fix:지도로보기중 게시글 작성시 지도 안보이는 버그 해결

### DIFF
--- a/client/src/component/article/MapType.js
+++ b/client/src/component/article/MapType.js
@@ -34,7 +34,7 @@ function MapType() {
       const fearMin =
         'https://cdn.discordapp.com/attachments/929022343689420871/929022391567384656/2022-01-07_11.37.37.png'
 
-      const container = document.getElementById('map')
+      const container = document.getElementById('type-map')
       const options = {
         center: new kakao.maps.LatLng(userPost[0].lat, userPost[0].lng),
         level: 9,
@@ -169,7 +169,7 @@ function MapType() {
   return (
     <>
       {userPost.length ? (
-        <MapSection id="map"></MapSection>
+        <MapSection id="type-map"></MapSection>
       ) : (
         <EmptyPosts>
           <p className="msg-md-gs">아직 작성하신 글이 없으시군요!</p>


### PR DESCRIPTION
MemoryIt 수정 필요 사항
- [x] 드래그로 위치 저장이 안되는 현상
- [x] 지도로보기에서 게시글 작성하면 지도 안나타나는 현상
- [ ] 지도로보기에서는 월별, 감정별 필터링 안됨