### PR TITLE
fix:맵타입에서도 게시글 생성,삭제시 리로딩 되게 수정중

### DIFF
--- a/client/src/component/article/MapType.js
+++ b/client/src/component/article/MapType.js
@@ -21,7 +21,54 @@ function MapType() {
   const { userPost } = useSelector(state => state.updateUserpostReducer)
   const dispatch = useDispatch()
   const { rightBarRef, rer, filteredColor } = useOutletContext()
+
+  // const [isLoading, setIsLoading] = useState(true)
+  // const [userPosts, setUserPosts] = useState([])
+
+  // const { monthCode } = useSelector(state => state.changeUserPostReducer)
+
+  // const filtering = (target, filterColor) => {
+  //   if (filterColor.length <= 0) {
+  //     filterColor = [1, 2, 3, 4, 5]
+  //   }
+  //   return target.filter(v => filterColor.find(w => v.emotions.includes(w)))
+  // }
+  // const spaceNone = arr => {
+  //   return arr.map(url => {
+  //     const strings = url.images.split(' ')
+
+  //     if (strings.length > 1) {
+  //       const replace = strings.join('%20')
+  //       return { ...url, images: replace }
+  //     } else return url
+  //   })
+  // }
+
+  // useEffect(async () => {
+  //   await axios
+  //     .get(
+  //       `${process.env.REACT_APP_SERVE}/posts?type=diary&month=${
+  //         monthCode + 1
+  //       }&year=2022`,
+  //       {
+  //         withCredentials: true,
+  //       }
+  //     )
+  //     .then(res => {
+  //       const beforeFiltering = res.data.data
+  //       const filtered = filtering(beforeFiltering, filteredColor)
+  //       const result = spaceNone(filtered)
+  //       setUserPosts(result)
+  //       setIsLoading(false)
+  //       dispatch(updateUserpost(res.data.data))
+  //     })
+  //     .catch(err => {
+  //       console.log('server error!')
+  //     })
+  // }, [monthCode, rer, filteredColor])
+
   useEffect(() => {
+    console.log('setRer!!')
     if (userPost.length) {
       const joyMin =
         'https://cdn.discordapp.com/attachments/929022343689420871/929022391311556628/2022-01-07_11.37.31.png'
@@ -165,7 +212,7 @@ function MapType() {
         }
       })
     }
-  }, [])
+  }, [rer])
   return (
     <>
       {userPost.length ? (


### PR DESCRIPTION
- 수정 - 
map type 상태에서도 게시글 생성,삭제시 자동으로 지도가 리로딩 되야함.
현재는 diary type에서만 서버와의 통신을 하고있고 그 정보를 리덕스 스토어에 저장한 뒤 map type으로 볼 때 스토어를 조회하는 형식.
map type에서도 게시글 CRUD 시 서버와 직접 통신을해서 정보를 즉각적으로 불러올 수 있게 수정이 필요함

maptype.js에 필요한 코드를 옮겨놓았고, 재사용가능한 코드는 또 작성하지말고 diary type에서 그대로 가져올 수 있게 정리하고 코드 변경완료후 불필요한 코드는 삭제 필요